### PR TITLE
create 'enzyme/globals' environment add a few globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
+
+You can also use the `enzyme/globals` environment if you are injecting `shallow`, `mount`, and `render` into the global scope: (for example if you are using [`jest-environment-enzyme`](https://github.com/FormidableLabs/enzyme-matchers/tree/master/packages/jest-environment-enzyme)) 
+```json
+{
+    "env": {
+        "enzyme/globals": true
+    }
+}
+
+```
 ## Supported Rules
 
 * [enzyme/no-shallow](docs/rules/no-shallow.md)

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,3 +19,12 @@ const requireIndex = require('requireindex');
 module.exports.rules = requireIndex(`${__dirname}/rules`);
 
 
+module.exports.environments = {
+  globals: {
+    globals: {
+      shallow: false,
+      mount: false,
+      render: false
+    }
+  }
+}


### PR DESCRIPTION
removes `no-undef` errors/warnings from `shallow`, `mount`, and `render` after injecting globals for Enzyme